### PR TITLE
msm8974: Allow telephony to control tap-to-wake procfs

### DIFF
--- a/rootdir/etc/init.qcom-common.rc
+++ b/rootdir/etc/init.qcom-common.rc
@@ -248,7 +248,7 @@ on post-fs-data
     mkdir /data/audio/ 0770 media audio
 
     # Touchscreen
-    chown root system /proc/touchpanel/double_tap_enable
+    chown system radio /proc/touchpanel/double_tap_enable
     chmod 0660 /proc/touchpanel/double_tap_enable
 
     chown root system /proc/touchpanel/camera_enable

--- a/sepolicy/radio.te
+++ b/sepolicy/radio.te
@@ -1,0 +1,3 @@
+# Telecom app can disable tap-to-wake
+allow radio proc_touchpanel:file rw_file_perms;
+allow radio proc_touchpanel:dir { search };


### PR DESCRIPTION
- Telephony will toggle this when the screen goes off via
  proximity, which is good because you don't want to
  facewake the thing. Add policy and set correct perms for
  this.

Change-Id: Ibf9e4bffd668563d171615936f24feba902cf884
