### PR TITLE
msm8974: Add type transition if generating MAC address

### DIFF
--- a/sepolicy/wcnss_service.te
+++ b/sepolicy/wcnss_service.te
@@ -1,0 +1,3 @@
+allow wcnss_service persist_file:dir { search write create add_name };
+
+type_transition wcnss_service persist_file:file wifi_data_file ".genmac";


### PR DESCRIPTION
- This "should never happen" in production as NV will be programmed,
  but we were missing the type transition to allow .genmac to be
  created. This was discovered on new sample hardware.

Change-Id: I48aef9d8e2892c18c3be901c1f76536d447f3c4c
